### PR TITLE
Fix to build with mono's xbuild on Non-Windows Systems.

### DIFF
--- a/src/JsonFx/JsonFx.csproj
+++ b/src/JsonFx/JsonFx.csproj
@@ -97,7 +97,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.XML" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFrameworkVersion)' != 'v2.0' And '$(TargetFrameworkVersion)' != 'v3.0' ">
     <Reference Include="System.Core" />


### PR DESCRIPTION
For some reason, the JsonFx.csproj uses a reference to System.XML
instead of System.Xml. The uppercase .XML is not understood by mono's
xbuild implementation and will result in a build failure. This fix
changes that and now build succeeds using latest mono and xbuild tool.

Tested to build successfully with mono 2.10.9 under OS X Lion.
