### PR TITLE
Don't throw DeserializationException for U+007F to U+009F

### DIFF
--- a/src/JsonFx.Tests/Json/JsonTokenizerTests.cs
+++ b/src/JsonFx.Tests/Json/JsonTokenizerTests.cs
@@ -427,6 +427,22 @@ namespace JsonFx.Json
 
 		[Fact]
 		[Trait(TraitName, TraitValue)]
+		public void GetTokens_HighControl_Accepted()
+		{
+			const string input = "\"\u0082\"";
+			var expected = new []
+			{
+				ModelGrammar.TokenPrimitive("\u0082")
+			};
+
+			var tokenizer = new JsonReader.JsonTokenizer();
+			var actual = tokenizer.GetTokens(input).ToArray();
+
+			Assert.Equal(expected, actual);
+		}
+
+		[Fact]
+		[Trait(TraitName, TraitValue)]
 		public void GetTokens_StringImproperlyEscapedChars_ReturnsStringTokenWithSimpleChars()
 		{
 			const string input = @"""\u\u1\u12\u123\u12345""";

--- a/src/JsonFx/Utils/CharUtility.cs
+++ b/src/JsonFx/Utils/CharUtility.cs
@@ -88,9 +88,7 @@ namespace JsonFx.Utils
 		/// <returns></returns>
 		public static bool IsControl(char ch)
 		{
-			return
-				(ch <= '\u001F') ||
-			    ((ch >= '\u007F') && (ch <= '\u009F'));
+			return (ch <= '\u001F');
 		}
 
 		/// <summary>


### PR DESCRIPTION
Hi,

JsonFX currently throws a `DeserializationException` if the input stream contains characters in the range U+007F to U+009F. http://json.org/ says control characters are not permitted and these are indeed control characters as per the Unicode standard. However, RFC 4627 has a narrower definition:

> All Unicode characters may be placed within the quotation marks except for the characters that must be escaped: quotation mark, reverse solidus, and the control characters (U+0000 through U+001F).

(See http://tools.ietf.org/html/rfc4627#section-2.5)

This is the definition that e.g. Google Chrome follows. For instance:

``` javascript
encodeURIComponent(JSON.stringify(String.fromCharCode(0x10)))
"%22%5Cu0010%22"
encodeURIComponent(JSON.stringify(String.fromCharCode(0x82)))
"%22%C2%82%22"
```

Patch attached.
