### PR TITLE
Adding UTF-16 surrogate pair support for Json formatter

### DIFF
--- a/src/JsonFx.Tests/Json/JsonFormatterTests.cs
+++ b/src/JsonFx.Tests/Json/JsonFormatterTests.cs
@@ -529,6 +529,24 @@ namespace JsonFx.Json
 
 		[Fact]
 		[Trait(TraitName, TraitValue)]
+		public void Format_StringTokenSurrogatePair_ReturnsString()
+		{
+			var input = new[]
+			{
+				// 'BLUE HEART' (U+1F499)
+				ModelGrammar.TokenPrimitive("\uD83D\uDC99")
+			};
+
+			const string expected = @"""\u1F499""";
+
+			var formatter = new JsonWriter.JsonFormatter(new DataWriterSettings());
+			var actual = formatter.Format(input);
+
+			Assert.Equal(expected, actual);
+		}
+
+		[Fact]
+		[Trait(TraitName, TraitValue)]
 		public void Format_StringTokenUnescapedSingleQuote_ReturnsString()
 		{
 			var input = new[]

--- a/src/JsonFx/Json/JsonFormatter.cs
+++ b/src/JsonFx/Json/JsonFormatter.cs
@@ -511,12 +511,14 @@ namespace JsonFx.Json
 
 			protected virtual void WriteString(TextWriter writer, string value)
 			{
-				int start = 0,
-					length = value.Length;
-
 				writer.Write(JsonGrammar.OperatorStringDelim);
 
-				for (int i=start; i<length; i++)
+				int[] combineCharIndex = StringInfo.ParseCombiningCharacters(value);
+
+				int start = 0,
+					length = combineCharIndex.Length;
+
+				foreach (int i in combineCharIndex)
 				{
 					char ch = value[i];
 


### PR DESCRIPTION
Hi,

The current JsonFormatter could not handle UTF-16 surrogate pair. It always throw an exception when trying to convert low surrogate char to UTF-32.

The change will get the index of each real character in the string instead of every code point.