### PR TITLE
Fixed the issue in serialization of emoji chars

### DIFF
--- a/src/JsonFx.Tests/Json/JsonFormatterTests.cs
+++ b/src/JsonFx.Tests/Json/JsonFormatterTests.cs
@@ -1270,5 +1270,24 @@ namespace JsonFx.Json
 		}
 
 		#endregion Input Edge Case Tests
+
+		#region Emoji Tests
+		[Fact]
+		[Trait(TraitName, TraitValue)]
+		public void Format_StringTokenWithEmoji_ReturnsStringWithEmoji()
+		{
+			var input = new[]
+			{
+				ModelGrammar.TokenPrimitive("Text with 😜 emoji 🎉"),
+			};
+
+			const string expected = @"""Text with \uD83D\uDE1C emoji \uD83C\uDF89""";
+
+			var formatter = new JsonWriter.JsonFormatter(new DataWriterSettings());
+			var actual = formatter.Format(input);
+
+			Assert.Equal(expected, actual);
+		}
+		#endregion
 	}
 }

--- a/src/JsonFx/Json/JsonFormatter.cs
+++ b/src/JsonFx/Json/JsonFormatter.cs
@@ -568,23 +568,9 @@ namespace JsonFx.Json
 							}
 							default:
 							{
-#if SILVERLIGHT
-								if (((ch >= 55296) && (ch <= 56319)) || ((ch >= 56320) && (ch <= 57343)))
-								{
-#else
-								if (char.IsSurrogate(ch))
-								{
-#endif
-									writer.Write("\\u");
-									writer.Write(((int)ch).ToString("x4"));
-									continue;
-								}
-								else
-								{
-									writer.Write("\\u");
-									writer.Write(CharUtility.ConvertToUtf32(value, i).ToString("X4"));
-									continue;
-								}
+								writer.Write("\\u");
+								writer.Write(CharUtility.ConvertToUtf32(value, i).ToString("X4"));
+								continue;
 							}
 						}
 					}

--- a/src/JsonFx/Json/JsonFormatter.cs
+++ b/src/JsonFx/Json/JsonFormatter.cs
@@ -511,8 +511,8 @@ namespace JsonFx.Json
 
 			protected virtual void WriteString(TextWriter writer, string value)
 			{
-                                int start = 0,
- 					length = value.Length;
+				int start = 0,
+ 				length = value.Length;
  
   				writer.Write(JsonGrammar.OperatorStringDelim);
 
@@ -569,23 +569,22 @@ namespace JsonFx.Json
 							default:
 							{
 #if SILVERLIGHT
-                                                                if (((ch >= 55296)
-                                                                    && (ch <= 56319)) || ((ch >= 56320) && (ch <= 57343)))
-                                                                {
+								if (((ch >= 55296) && (ch <= 56319)) || ((ch >= 56320) && (ch <= 57343)))
+								{
 #else
-                                                                if (char.IsSurrogate(ch))
-                                                                {
+								if (char.IsSurrogate(ch))
+								{
 #endif
-                                                                    writer.Write("\\u");
-                                                                    writer.Write(((int)ch).ToString("x4"));
-                                                                    continue;
-                                                                }
-                                                                else
-                                                                {
-                                                                    writer.Write("\\u");
-                                                                    writer.Write(CharUtility.ConvertToUtf32(value, i).ToString("X4"));
-                                                                    continue;
-                                                                }
+									writer.Write("\\u");
+									writer.Write(((int)ch).ToString("x4"));
+									continue;
+								}
+								else
+								{
+									writer.Write("\\u");
+									writer.Write(CharUtility.ConvertToUtf32(value, i).ToString("X4"));
+									continue;
+								}
 							}
 						}
 					}

--- a/src/JsonFx/Json/JsonFormatter.cs
+++ b/src/JsonFx/Json/JsonFormatter.cs
@@ -512,11 +512,11 @@ namespace JsonFx.Json
 			protected virtual void WriteString(TextWriter writer, string value)
 			{
 				int start = 0,
- 				length = value.Length;
- 
-  				writer.Write(JsonGrammar.OperatorStringDelim);
+					length = value.Length;
 
- 				for (int i=start; i<length; i++)
+				writer.Write(JsonGrammar.OperatorStringDelim);
+
+				for (int i=start; i<length; i++)
 				{
 					char ch = value[i];
 

--- a/src/JsonFx/Json/JsonFormatter.cs
+++ b/src/JsonFx/Json/JsonFormatter.cs
@@ -511,12 +511,12 @@ namespace JsonFx.Json
 
 			protected virtual void WriteString(TextWriter writer, string value)
 			{
-				int start = 0,
-					length = value.Length;
+                                int start = 0,
+ 					length = value.Length;
+ 
+  				writer.Write(JsonGrammar.OperatorStringDelim);
 
-				writer.Write(JsonGrammar.OperatorStringDelim);
-
-				for (int i=start; i<length; i++)
+ 				for (int i=start; i<length; i++)
 				{
 					char ch = value[i];
 
@@ -568,9 +568,24 @@ namespace JsonFx.Json
 							}
 							default:
 							{
-								writer.Write("\\u");
-								writer.Write(CharUtility.ConvertToUtf32(value, i).ToString("X4"));
-								continue;
+#if SILVERLIGHT
+                                                                if (((ch >= 55296)
+                                                                    && (ch <= 56319)) || ((ch >= 56320) && (ch <= 57343)))
+                                                                {
+#else
+                                                                if (char.IsSurrogate(ch))
+                                                                {
+#endif
+                                                                    writer.Write("\\u");
+                                                                    writer.Write(((int)ch).ToString("x4"));
+                                                                    continue;
+                                                                }
+                                                                else
+                                                                {
+                                                                    writer.Write("\\u");
+                                                                    writer.Write(CharUtility.ConvertToUtf32(value, i).ToString("X4"));
+                                                                    continue;
+                                                                }
 							}
 						}
 					}

--- a/src/JsonFx/Utils/CharUtility.cs
+++ b/src/JsonFx/Utils/CharUtility.cs
@@ -169,7 +169,14 @@ namespace JsonFx.Utils
 #if SILVERLIGHT
 			return (int)value[index];
 #else
-			return Char.ConvertToUtf32(value, index);
+			if (char.IsSurrogate(value[index]))
+			{
+				return ((int)value[index]);
+			}
+			else
+			{
+				return Char.ConvertToUtf32(value, index);
+			}
 #endif
 		}
 

--- a/src/JsonFx/Utils/CharUtility.cs
+++ b/src/JsonFx/Utils/CharUtility.cs
@@ -169,7 +169,7 @@ namespace JsonFx.Utils
 #if SILVERLIGHT
 			return (int)value[index];
 #else
-			if (char.IsSurrogate(value[index]))
+			if (char.IsSurrogate(value, index))
 			{
 				return ((int)value[index]);
 			}


### PR DESCRIPTION
On serializing a text with emoji in it (Text with 😜 emoji 🎉), using the code (running on Mono framework ver 3.2.5):

```
var writer = new JsonFx.Json.JsonWriter ();
string json = writer.Write (objectToSerialize);
```

the library threw an exception: "The string contains invalid surrogate pair character at….". 

This has been fixed in this pull request. 
